### PR TITLE
5-mining-button-color-wrong

### DIFF
--- a/src/qt/stakepage.cpp
+++ b/src/qt/stakepage.cpp
@@ -46,6 +46,8 @@ StakePage::StakePage(const PlatformStyle *_platformStyle, QWidget *parent) :
     ui->checkStake->setEnabled(gArgs.GetBoolArg("-staking", DEFAULT_STAKE));
     transactionView = new TransactionView(platformStyle, this, true);
     ui->frameStakeRecords->layout()->addWidget(transactionView);
+    ui->checkStake->update();
+    ui->checkStake->show();
 }
 
 StakePage::~StakePage()


### PR DESCRIPTION
Mining button initialized with proper background color when started.
Blue when mining, grey when mining is disabled. Color toggles correctly.