### PR TITLE
14-block-reindex-error

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4078,9 +4078,12 @@ bool CChainState::UpdateHashProof(const CBlock& block, BlockValidationState& sta
     if (block.IsProofOfStake() && !CheckCoinStakeTimestamp(block.GetBlockTime()))
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-proof-of-stake-timestamp", strprintf("UpdateHashProof() : coinstake timestamp violation nTimeBlock=%d", block.GetBlockTime()));
 
-    // Check proof-of-work or proof-of-stake
-    if (block.nBits != GetNextWorkRequired(pindex->pprev, &block, consensusParams))
-        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-proof-of-work-or-stake", strprintf("UpdateHashProof() : incorrect %s", block.IsProofOfWork() ? "proof-of-work" : "proof-of-stake"));
+    // Check proof-of-work or proof-of-stake; genesis does not have a previous block, skip.
+    if (0 != nHeight)
+    {
+        if (block.nBits != GetNextWorkRequired(pindex->pprev, &block, consensusParams))
+            return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-proof-of-work-or-stake", strprintf("UpdateHashProof() : incorrect %s", block.IsProofOfWork() ? "proof-of-work" : "proof-of-stake"));
+    }
 
     uint256 hashProof;
     // Verify hash target and signature of coinstake tx


### PR DESCRIPTION
The Genesis block does not contain a previous block, must skip the check in that case.
Tested and verified -reindex=1 results in a successful reindex and node continues to operate successfully.